### PR TITLE
#164047067 feature enable user to comment on articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,3 @@ db.sqlite3
 
 #migration
 **/migrations/*
-!**/migrations/__init__.py

--- a/authors/apps/article/models.py
+++ b/authors/apps/article/models.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 
 from authors.apps.authentication.models import User
+from ..profiles.models import UserProfile
 
 
 # Create your models here.
@@ -41,9 +42,6 @@ class Article(models.Model):
                 origin += 1
             self.slug = unique_slug
         super().save(*args, **kwargs)
-
-    class Meta:
-        ordering = ('created_at',)
 
 
 class ArticleImage(models.Model):
@@ -144,3 +142,21 @@ class ArticleLikes(models.Model):
                 'Successfully undid (dis)like on {} article'.format(slug),
             'article': ArticleSerializer(article).data
         }, status=status.HTTP_202_ACCEPTED)
+        
+class ArticleComment(models.Model):
+    createdAt = models.DateTimeField(auto_now_add=True)
+    updatedAt = models.DateTimeField(auto_now=True)
+    article = models.ForeignKey(
+        Article, related_name="comments", on_delete=models.CASCADE, to_field="slug")
+    parent_comment = models.ForeignKey(
+        'self', related_name='subcomments',  on_delete=models.CASCADE, blank=True, null=True)
+    body = models.TextField(blank=False)
+    author = models.ForeignKey(
+        UserProfile, related_name="comments", on_delete=models.CASCADE)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        ordering = ('createdAt',)
+
+    def __str__(self):
+        return self.body[:20]

--- a/authors/apps/article/renderer.py
+++ b/authors/apps/article/renderer.py
@@ -19,3 +19,58 @@ class ArticleJSONRenderer(JSONRenderer):
         return json.dumps({
             "article": 'No article found.'
         })
+
+class CommentJSONRenderer(JSONRenderer):
+    charset = 'utf-8'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        
+        if isinstance(data, dict):
+            errors = data.get('errors', None)
+            is_active = data.get('is_active', None)
+
+            if errors is not None:
+                
+                return super(CommentJSONRenderer, self).render(data)
+
+            if is_active is not None:
+                data = self.filter_data(data)
+
+            return json.dumps({
+                'comment': data
+            })
+
+        for comment in data:
+            comment = self.filter_data(comment)
+
+        return json.dumps({
+                'comments': data,
+                'commentsCount': len(data)
+            })
+
+    def filter_data(self, data):
+        if data['is_active'] == False:
+            del data['is_active']
+            del data['article']
+            del data['author']
+            del data['id']
+            del data['createdAt']
+            del data['updatedAt']
+            del data['body']
+            data['comment'] = "deleted"
+        else:
+            del data['is_active']
+            del data['article']
+            data['author'] = {
+                        "username": data['author']['username'],
+                        "bio": data['author']['bio'],
+                        "image": data['author']['avatar'],
+                        "following": data['author']['following']
+                    }
+
+        if len(data['subcomments']) > 0:
+            for comment in data['subcomments']:
+                comment = self.filter_data(comment)
+
+        return data
+

--- a/authors/apps/article/serializers.py
+++ b/authors/apps/article/serializers.py
@@ -3,8 +3,7 @@ from django.db.models import Avg
 from rest_framework import serializers
 
 from authors.apps.authentication.serializers import UserSerializer
-from .models import Article, ArticleLikes
-from .models import Rate
+from .models import Article, ArticleLikes, Rate
 
 
 class LikesSerializer(serializers.ModelSerializer):
@@ -16,6 +15,11 @@ class LikesSerializer(serializers.ModelSerializer):
     class Meta:
         model = ArticleLikes
         fields = ('user',)
+
+from .models import Article, ArticleComment
+
+from authors.apps.authentication.serializers import UserSerializer
+from ..profiles.serializers import ProfileSerializer
 
 
 class ArticleSerializer(serializers.ModelSerializer):
@@ -145,3 +149,34 @@ class RateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Rate
         fields = ('article', 'average_rating', 'rate_count', 'your_rating')
+
+
+class SubcommentSerializer(serializers.ModelSerializer):
+    author = ProfileSerializer(read_only=True)
+
+    class Meta:
+        model = ArticleComment
+        fields = ['id', 'article', 'createdAt', 'updatedAt',
+                  'body', 'author', 'is_active', 'subcomments']
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    """
+    converts the model into JSON format
+    """
+    subcomments = SubcommentSerializer(many=True, read_only=True)
+    author = ProfileSerializer(read_only=True)
+
+    class Meta:
+        model = ArticleComment
+        fields = ['id', 'article', 'createdAt', 'updatedAt',
+                  'body', 'author', 'is_active', 'subcomments']
+
+
+class DeleteCommentSerializer(serializers.ModelSerializer):
+    """
+    converts the model into JSON format
+    """
+    class Meta:
+        model = ArticleComment
+        fields = ['is_active']

--- a/authors/apps/article/tests/test_comments.py
+++ b/authors/apps/article/tests/test_comments.py
@@ -1,0 +1,274 @@
+"""Test API endpoints"""
+import json
+from rest_framework.test import APITestCase, APIClient
+from rest_framework.views import status
+from ...authentication.models import User
+
+
+class UserTest(APITestCase):
+    client = APIClient()
+
+    def setUp(self):
+        # add test data
+        self.user = {
+            "user": {
+                "email": "caro@yahoo.com",
+                "username": "caro",
+                "password": "07921513542"
+            }
+        }
+
+        self.profile = {
+            "bio": "am fantastic",
+            "interests": "football",
+            "favorite_quote": "Yes we can",
+            "mailing_address": "P.O BOX 1080",
+            "website": "http://www.web.com",
+            "active_profile": True
+        }
+
+        self.article = {
+            "title": "Andela",
+            "description": "sdsd",
+            "body": "dsd",
+            "images": ""
+        }
+
+        self.comment = {
+            "comment": {
+                "body": "His name was my name too."
+            }
+        }
+
+        # create user
+        self.client.post('/api/users/', self.user, format='json')
+        # user login
+        response = self.client.post(
+            '/api/users/login/', self.user, format='json')
+        result = json.loads(response.content)
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + result["user"]["token"])
+
+        # create profile
+        self.client.post(
+            '/api/profile/create_profile/', self.profile, format='json')
+
+        # create article
+        response = self.client.post(
+            '/api/articles/', self.article, format='json')
+
+    def test_create_comment(self):
+        """
+        test create comment
+        """
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["body"],
+                         "His name was my name too.")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_subcomment_of_comment(self):
+        """
+        test create comment
+        """
+        # create comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        # create subcomment of comment
+        response = self.client.post(
+            '/api/articles/andela/comments/' + str(result["comment"]["id"]) + "/subcomment", self.comment, format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["body"],
+                         "His name was my name too.")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_comment_non_existing_article(self):
+        """
+        test create comment
+        """
+        response = self.client.post(
+            '/api/articles/ndela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["error"], "Article does not exist!")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_comment_non_existing_profile(self):
+        """
+        test create comment
+        """
+        # create user
+        self.user['user']['email'] = "james@gmail.com"
+        self.user['user']['username'] = "james"
+        self.user['user']['password'] = "4567890123"
+        self.client.post('/api/users/', self.user, format='json')
+        # user login
+        response = self.client.post(
+            '/api/users/login/', self.user, format='json')
+        result = json.loads(response.content)
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + result["user"]["token"])
+
+        # create comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["error"],
+                         "Permission denied! You don't have a profile")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_article_comments(self):
+        """
+        test get comments
+        """
+        # create article comments
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+
+        # get article comments
+        response = self.client.get(
+            '/api/articles/andela/comments/', format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["commentsCount"], 3)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_comment(self):
+        """
+        test get comment
+        """
+        # create article comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        # get comment
+        response = self.client.get(
+            '/api/articles/andela/comments/' + str(result["comment"]["id"]), format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["body"],
+                         "His name was my name too.")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_subcomment_of_comment(self):
+        """
+        test get comment
+        """
+        # create article comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        main_comment = str(result["comment"]["id"])
+
+        # create subcomment of comment
+        response = self.client.post(
+            '/api/articles/andela/comments/' + main_comment + "/subcomment", self.comment, format='json')
+        result = json.loads(response.content)
+
+        # get sub comments
+        response = self.client.get(
+            '/api/articles/andela/comments/' + main_comment + "/subcomment", format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["commentsCount"], 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_non_existing_comment(self):
+        """
+        test get comment
+        """
+        response = self.client.get(
+            '/api/articles/andela/comments/350', format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["error"], "comment does not exist!")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_edit_comment(self):
+        """
+        test get comment
+        """
+        # create article comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        # edit comment
+        self.comment['comment']['body'] = "am edited"
+        response = self.client.put(
+            '/api/articles/andela/comments/' + str(result["comment"]["id"]), self.comment, format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["body"], "am edited")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_comment(self):
+        """
+        test delete comment
+        """
+        # create article comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        # delete comment
+        response = self.client.delete(
+            '/api/articles/andela/comments/' + str(result["comment"]["id"]), format='json')
+
+        self.assertEqual(response.data["message"],
+                         "comment deleted successfully")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_edit_other_persons_comment(self):
+        """
+        test edit comment
+        """
+        # create article comment
+        response = self.client.post(
+            '/api/articles/andela/comments/', self.comment, format='json')
+        result = json.loads(response.content)
+
+        edit_comment = str(result["comment"]["id"])
+
+        # create user
+        self.user['user']['email'] = "james@gmail.com"
+        self.user['user']['username'] = "james"
+        self.user['user']['password'] = "4567890123"
+        self.client.post('/api/users/', self.user, format='json')
+        # user login
+        response = self.client.post(
+            '/api/users/login/', self.user, format='json')
+        result = json.loads(response.content)
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + result["user"]["token"])
+
+        # create profile
+        self.client.post(
+            '/api/profile/create_profile/', self.profile, format='json')
+
+        # edit comment
+        self.comment['comment']['body'] = "am edited"
+        response = self.client.put(
+            '/api/articles/andela/comments/' + edit_comment, self.comment, format='json')
+        result = json.loads(response.content)
+
+        self.assertEqual(result["comment"]["error"],
+                         "You do not have that permission on this comment!")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/authors/apps/article/urls.py
+++ b/authors/apps/article/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
-from .views import (ArticlesAPIView, RetrieveArticleAPIView, LikeAPIView, DislikeAPIView, RateAPIView)
+from .views import (ArticlesAPIView, RetrieveArticleAPIView, RateAPIView, LikeAPIView, DislikeAPIView,
+                    CommentsAPIView, RetrieveCommentsAPIView, SubCommentAPIView)
 
 app_name = "articles"
 
@@ -10,6 +11,7 @@ urlpatterns = [
     path('rate/<slug>/', RateAPIView.as_view(), name='rate'),
     path('articles/<slug>/like', LikeAPIView.as_view()),
     path('articles/<slug>/dislike', DislikeAPIView.as_view()),
+    path('articles/<slug>/comments/', CommentsAPIView.as_view()),
+    path('articles/<slug>/comments/<pk>', RetrieveCommentsAPIView.as_view()),
+    path('articles/<slug>/comments/<pk>/subcomment', SubCommentAPIView.as_view())
 ]
-    
-

--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -14,7 +14,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 				'username_id', 'username', 'bio',
 				'avatar', 'interests', 'favorite_quote',
 				'created', 'mailing_address', 'website',
-				'contact_phone', 'active_profile'
+				'contact_phone', 'active_profile', 'following'
 				]
 
 


### PR DESCRIPTION
#### What does this PR do?
Enables user to:
- comment on articles
- fetch all comments of an article
- comment on comment
- fetch comment sub-comments
- fetch specific comment
- edit comment
- delete comment
#### Description of Task to be completed?
create the following API endpoints:
```
- POST articles/<slug>/comments/
- GET articles/<slug>/comments/
- POST articles/<slug>/comments/<pk>
- GET articles/<slug>/comments/<pk>
- PUT articles/<slug>/comments/<pk>
- DELETE articles/<slug>/comments/<pk>
- POST articles/<slug>/comments/<pk>/subcomment
- GET articles/<slug>/comments/<pk>/subcomment
```

#### How should this be manually tested?
- clone project
- run server
- access above endpoints
comment body should be
```
{
  "comment": {
    "body": "His name was my name too."
  }
}
```

#### What are the relevant pivotal tracker stories?
[#164047067](https://www.pivotaltracker.com/story/show/164047067)

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2019-03-15 at 21 09 52" src="https://user-images.githubusercontent.com/39084014/54452684-ccd10f00-4766-11e9-956d-6a107f59bef8.png">

